### PR TITLE
Fix syntax error in login

### DIFF
--- a/grindr_user.py
+++ b/grindr_user.py
@@ -58,7 +58,7 @@ class GrindrUser:
 
             if response["code"] == 27:
                 self.banned = True
-                raise Exception(f'Banned for {response['reason']}')
+                raise Exception(f"Banned for {response['reason']}")
 
             if response["code"] == 28:
                 self.banned = True


### PR DESCRIPTION
## Summary
- fix quoting in login exception string

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_685dc2a2286c832381e0c18a2d5ad101